### PR TITLE
Replace javax.xml.bind.Datatype with class

### DIFF
--- a/src/main/java/com/akamai/edgeauth/EdgeAuth.java
+++ b/src/main/java/com/akamai/edgeauth/EdgeAuth.java
@@ -30,8 +30,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 
+import static com.akamai.edgeauth.hexutils.DataTypeConverter.parseHexBinary;
 
 /**
  * This is for returning authorization token string. You can build an instance 
@@ -280,7 +280,7 @@ public class EdgeAuth {
 
         try {
             Mac hmac = Mac.getInstance(this.algorithm);
-            byte[] keyBytes = DatatypeConverter.parseHexBinary(this.key);
+            byte[] keyBytes = parseHexBinary(this.key);
             SecretKeySpec secretKey = new SecretKeySpec(keyBytes, this.algorithm);
             hmac.init(secretKey);
 

--- a/src/main/java/com/akamai/edgeauth/hexutils/DataTypeConverter.java
+++ b/src/main/java/com/akamai/edgeauth/hexutils/DataTypeConverter.java
@@ -1,0 +1,42 @@
+package com.akamai.edgeauth.hexutils;
+
+/**
+ * This code was copied from javax.xml.bind.DatatypeConverter.parseHexBinary which is not available in JDK 11+.
+ */
+public class DataTypeConverter {
+    public static byte[] parseHexBinary(String s) {
+        final int len = s.length();
+
+        // "111" is not a valid hex encoding.
+        if (len % 2 != 0) {
+            throw new IllegalArgumentException("hexBinary needs to be even-length: " + s);
+        }
+
+        byte[] out = new byte[len / 2];
+
+        for (int i = 0; i < len; i += 2) {
+            int h = hexToBin(s.charAt(i));
+            int l = hexToBin(s.charAt(i + 1));
+            if (h == -1 || l == -1) {
+                throw new IllegalArgumentException("contains illegal character for hexBinary: " + s);
+            }
+
+            out[i / 2] = (byte) (h * 16 + l);
+        }
+
+        return out;
+    }
+
+    private static int hexToBin(char ch) {
+        if ('0' <= ch && ch <= '9') {
+            return ch - '0';
+        }
+        if ('A' <= ch && ch <= 'F') {
+            return ch - 'A' + 10;
+        }
+        if ('a' <= ch && ch <= 'f') {
+            return ch - 'a' + 10;
+        }
+        return -1;
+    }
+}

--- a/src/test/java/com/akamai/edgeauth/hexutils/DataTypeConverterTest.java
+++ b/src/test/java/com/akamai/edgeauth/hexutils/DataTypeConverterTest.java
@@ -1,0 +1,61 @@
+package com.akamai.edgeauth.hexutils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.akamai.edgeauth.hexutils.DataTypeConverter.parseHexBinary;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class DataTypeConverterTest {
+    @Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {"00", new byte[]{0x00}},
+            {"0A", new byte[]{0x0A}},
+            {"ABCD", new byte[]{(byte) 0xAB, (byte) 0xCD}},
+            {"DEADBEEF", new byte[]{(byte) 0xDE, (byte) 0xAD, (byte) 0xBE, (byte) 0xEF}},
+            {"CAFEBABE", new byte[]{(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE}}});
+    }
+
+    private String valueAsString;
+    private byte[] valueAsByteArray;
+
+    public DataTypeConverterTest(String valueAsString, byte[] valueAsByteArray) {
+        this.valueAsString = valueAsString;
+        this.valueAsByteArray = valueAsByteArray;
+    }
+
+    @Test
+    public void convertsHexadecimalStringsToByteArrays() {
+        assertArrayEquals(parseHexBinary(valueAsString), valueAsByteArray);
+    }
+
+    @Test
+    public void throwsIllegalArgumentExceptionWhenInputHasOddNumberOfCharacters() {
+        try {
+            parseHexBinary("0");
+            fail("should have thrown exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "hexBinary needs to be even-length: 0");
+            return;
+        }
+    }
+
+    @Test
+    public void throwsIllegalArgumentExceptionWhenInputContainsIllegalCharacter() {
+        try {
+            parseHexBinary("0G");
+            fail("should have thrown exception");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "contains illegal character for hexBinary: 0G");
+        }
+    }
+}


### PR DESCRIPTION
The javax.xml.bind module was deprecated in Java 9 and removed in Java 11 - https://openjdk.java.net/jeps/320

In order to prevent manually importing javax.xml.bind.datatype, this replaces it with a class with the one static method used from the package.