### PR TITLE
DXE-3668 Release/1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change log
+
+## 1.0.0 (March 13, 2024)
+
+### Fixes
+
+* Modernized code to make it working with Java 8+
+* Resolved various CVE vulnerabilities
+* Resolved various Javadoc warnings
+* Rewritten unit tests
+* Migrated build system from Gradle to Maven for easier publish to Sonatype
+* Code cleaned up

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.akamai</groupId>
     <artifactId>edgeauth</artifactId>
-    <version>1.0.0-rc.1</version>
+    <version>1.0.0</version>
     <name>EdgeAuth-Token-Java</name>
     <description>Akamai Edge Authorization Token for Java</description>
     <url>https://github.com/akamai/EdgeAuth-Token-Java</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.akamai</groupId>
     <artifactId>edgeauth</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-rc.1</version>
     <name>EdgeAuth-Token-Java</name>
     <description>Akamai Edge Authorization Token for Java</description>
     <url>https://github.com/akamai/EdgeAuth-Token-Java</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.akamai</groupId>
     <artifactId>edgeauth</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>EdgeAuth-Token-Java</name>
     <description>Akamai Edge Authorization Token for Java</description>
     <url>https://github.com/akamai/EdgeAuth-Token-Java</url>


### PR DESCRIPTION
## 1.0.0 (March 13, 2024)

### Fixes

* Modernized code to make it working with Java 8+
* Resolved various CVE vulnerabilities
* Resolved various Javadoc warnings
* Rewritten unit tests
* Migrated build system from Gradle to Maven for easier publish to Sonatype
* Code cleaned up
